### PR TITLE
Rename nodeEvent to event and update package usage

### DIFF
--- a/client/Event.d.ts
+++ b/client/Event.d.ts
@@ -4,9 +4,9 @@ interface InitOptions {
     protocol: string;
 }
 type Callback<T = any> = (payload: T) => void;
-declare const nodeEvent: {
+declare const event: {
     init({ host, port, protocol }: InitOptions): void;
     subscribe<T = any>(type: string, callback: Callback<T>): () => void;
     publish<T = any>(...args: [...string[], T]): void;
 };
-export { nodeEvent };
+export { event };

--- a/client/Event.js
+++ b/client/Event.js
@@ -1,10 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.nodeEvent = void 0;
+exports.event = void 0;
 var socket_io_client_1 = require("socket.io-client");
 var socket = null;
 var callbacks = {};
-var nodeEvent = {
+var event = {
     init: function (_a) {
         var host = _a.host, port = _a.port, protocol = _a.protocol;
         if (socket)
@@ -19,7 +19,7 @@ var nodeEvent = {
     },
     subscribe: function (type, callback) {
         if (!socket)
-            throw new Error("nodeEvent not initialized. Call nodeEvent.init first.");
+            throw new Error("Event not initialized. Call event.init first.");
         if (!callbacks[type])
             callbacks[type] = new Set();
         callbacks[type].add(callback);
@@ -38,7 +38,7 @@ var nodeEvent = {
             args[_i] = arguments[_i];
         }
         if (!socket)
-            throw new Error("nodeEvent not initialized. Call nodeEvent.init first.");
+            throw new Error("Event not initialized. Call event.init first.");
         if (args.length < 2) {
             throw new Error("publish requires at least one event type and a payload");
         }
@@ -50,4 +50,4 @@ var nodeEvent = {
         });
     },
 };
-exports.nodeEvent = nodeEvent;
+exports.event = event;

--- a/client/Event.ts
+++ b/client/Event.ts
@@ -10,7 +10,7 @@ interface InitOptions {
 }
 type Callback<T = any> = (payload: T) => void;
 
-const nodeEvent = {
+const event = {
   init({ host, port, protocol }: InitOptions) {
     if (socket) return; 
     socket = io(`${protocol}://${host}:${port}`);
@@ -23,7 +23,7 @@ const nodeEvent = {
 
   subscribe<T = any>(type: string, callback: Callback<T>): () => void {
     if (!socket)
-      throw new Error("nodeEvent not initialized. Call nodeEvent.init first.");
+      throw new Error("Event not initialized. Call event.init first.");
     if (!callbacks[type]) callbacks[type] = new Set();
     callbacks[type].add(callback as Callback);
     socket!.emit("subscribe", type);
@@ -38,7 +38,7 @@ const nodeEvent = {
 
   publish<T = any>(...args: [...string[], T]): void {
     if (!socket)
-      throw new Error("nodeEvent not initialized. Call nodeEvent.init first.");
+      throw new Error("Event not initialized. Call event.init first.");
     
     if (args.length < 2) {
       throw new Error("publish requires at least one event type and a payload");
@@ -54,4 +54,4 @@ const nodeEvent = {
   },
 };
 
-export { nodeEvent };
+export { event };

--- a/sample/publisher/index.js
+++ b/sample/publisher/index.js
@@ -1,14 +1,14 @@
 const express = require("express");
-const { nodeEvent } = require("nuc-node-event-test/client");
+const { event } = require("@nucleoidai/node-event/client");
 
 const app = express();
 app.use(express.json());
 
-nodeEvent.init({ host: "localhost", port: 8080 });
+event.init({ host: "localhost", port: 8080 });
 
 app.post("/send", (req, res) => {
   const { type = "test", payload = {} } = req.body;
-  nodeEvent.publish(type, payload);
+  event.publish(type, payload);
   res.json({ status: "sent", type, payload });
 });
 

--- a/sample/publisher/package-lock.json
+++ b/sample/publisher/package-lock.json
@@ -8,8 +8,22 @@
       "name": "node-event-publisher",
       "version": "1.0.0",
       "dependencies": {
-        "express": "^4.18.2",
-        "nuc-node-event-test": "^1.0.13"
+        "@nucleoidai/node-event": "^1.1.1",
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/@nucleoidai/node-event": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nucleoidai/node-event/-/node-event-1.1.1.tgz",
+      "integrity": "sha512-Mi+c3jEBxO3oveA3lmHUyCo03DhIA+HEVTiqeH6xIWmUVziMVA6EmLIf26/4HyNNE+AUjy2m966t989wgOfFEg==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "server": "server/server.js"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -26,11 +40,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/accepts": {
@@ -661,20 +675,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nuc-node-event-test": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.13.tgz",
-      "integrity": "sha512-q0hh7CtlJfqDiEqedQF5I61HYqUM1Q49XaHZokF5bJ3AkpMvuYpbGRPChlqnXqD4ZnuZws0bX/5+OfrYeR+RhA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "server": "server/server.js"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/sample/publisher/package.json
+++ b/sample/publisher/package.json
@@ -6,7 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "nuc-node-event-test": "^1.0.13"
+    "@nucleoidai/node-event": "^1.1.1",
+    "express": "^4.18.2"
   }
 }

--- a/sample/subscriber/index.js
+++ b/sample/subscriber/index.js
@@ -1,11 +1,11 @@
 const express = require('express');
-const { nodeEvent } = require('nuc-node-event-test/client');
+const { event } = require('@nucleoidai/node-event/client');
 
 const app = express();
 
-nodeEvent.init({ host: 'localhost', port: 8080 });
+event.init({ host: 'localhost', port: 8080 });
 
-nodeEvent.subscribe('test', (payload) => {
+event.subscribe('test', (payload) => {
   console.log('Received event:', payload);
 });
 

--- a/sample/subscriber/package-lock.json
+++ b/sample/subscriber/package-lock.json
@@ -8,8 +8,22 @@
       "name": "node-event-subscriber",
       "version": "1.0.0",
       "dependencies": {
-        "express": "^4.18.2",
-        "nuc-node-event-test": "^1.0.13"
+        "@nucleoidai/node-event": "^1.1.1",
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/@nucleoidai/node-event": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nucleoidai/node-event/-/node-event-1.1.1.tgz",
+      "integrity": "sha512-Mi+c3jEBxO3oveA3lmHUyCo03DhIA+HEVTiqeH6xIWmUVziMVA6EmLIf26/4HyNNE+AUjy2m966t989wgOfFEg==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "server": "server/server.js"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -26,11 +40,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/accepts": {
@@ -661,20 +675,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nuc-node-event-test": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.13.tgz",
-      "integrity": "sha512-q0hh7CtlJfqDiEqedQF5I61HYqUM1Q49XaHZokF5bJ3AkpMvuYpbGRPChlqnXqD4ZnuZws0bX/5+OfrYeR+RhA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "server": "server/server.js"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/sample/subscriber/package.json
+++ b/sample/subscriber/package.json
@@ -6,7 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "nuc-node-event-test": "^1.0.13"
+    "@nucleoidai/node-event": "^1.1.1",
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
Renamed all references of 'nodeEvent' to 'event' in the client library and sample apps. Updated sample publisher and subscriber to use the '@nucleoidai/node-event' package instead of 'nuc-node-event-test'. Adjusted import paths and error messages accordingly.