### PR TITLE
Make port optional in event client initialization

### DIFF
--- a/client/Event.d.ts
+++ b/client/Event.d.ts
@@ -1,6 +1,6 @@
 interface InitOptions {
     host: string;
-    port: number;
+    port?: number;
     protocol: string;
 }
 type Callback<T = any> = (payload: T) => void;

--- a/client/Event.js
+++ b/client/Event.js
@@ -9,7 +9,8 @@ var event = {
         var host = _a.host, port = _a.port, protocol = _a.protocol;
         if (socket)
             return;
-        socket = (0, socket_io_client_1.io)("".concat(protocol, "://").concat(host, ":").concat(port));
+        var socketPath = port ? "".concat(protocol, "://").concat(host, ":").concat(port) : "".concat(protocol, "://").concat(host);
+        socket = (0, socket_io_client_1.io)(socketPath);
         socket.on("event", function (_a) {
             var type = _a.type, payload = _a.payload;
             if (callbacks[type]) {

--- a/client/Event.ts
+++ b/client/Event.ts
@@ -5,7 +5,7 @@ const callbacks: Record<string, Set<Callback>> = {};
 
 interface InitOptions {
   host: string;
-  port: number;
+  port?: number;
   protocol: string;
 }
 type Callback<T = any> = (payload: T) => void;
@@ -13,7 +13,8 @@ type Callback<T = any> = (payload: T) => void;
 const event = {
   init({ host, port, protocol }: InitOptions) {
     if (socket) return; 
-    socket = io(`${protocol}://${host}:${port}`);
+    const socketPath = port ? `${protocol}://${host}:${port}` : `${protocol}://${host}`;
+    socket = io(socketPath);
     socket.on("event", ({ type, payload }: { type: string; payload: any }) => {
       if (callbacks[type]) {
         callbacks[type].forEach((cb) => cb(payload));


### PR DESCRIPTION
Updated InitOptions to allow port to be optional. Adjusted socket connection logic to handle cases where port is not provided, improving flexibility for different connection scenarios.